### PR TITLE
Remove .DS_Store from .gitignore (now managed globally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,3 @@ tmp/*
 app/agent_design_pattern/tmp/*
 !app/agent_design_pattern/tmp/.gitkeep
 
-.DS_store


### PR DESCRIPTION
.DS_Store is now ignored via global gitignore configuration

🤖 Generated with [Claude Code](https://claude.ai/code)