### PR TITLE
docs: Azure OpenAI向けにinit_chat_modelとinit_embeddingsの使用方法を追加

### DIFF
--- a/docs/azure_opneai.md
+++ b/docs/azure_opneai.md
@@ -71,6 +71,34 @@ model = AzureChatOpenAI(
 > [!WARNING]
 > azure_deployment には、Azure OpenAI Service で設定したデプロイ名を設定します。
 
+## LangChian の init_chat_model
+
+LangChain の init_chat_model を使用する箇所は、以下のように変更します。
+
+変更前
+
+```python
+model = init_chat_model(
+    model="gpt-5-nano",
+    model_provider="openai",
+    reasoning_effort="minimal",
+)
+```
+
+変更後
+
+```python
+model = init_chat_model(
+    model="gpt-5-nano",
+    model_provider="azure_openai",
+    api_version="2024-08-01-preview",
+    reasoning_effort="minimal",
+)
+```
+
+> [!WARNING]
+> model には、Azure OpenAI Service で設定したデプロイ名を設定します。
+
 ## LangChian の OpenAIEmbeddings
 
 LangChain の OpenAIEmbeddings を使用する箇所は、以下のように変更します。
@@ -89,6 +117,29 @@ embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
 from langchain_openai import AzureOpenAIEmbeddings
 
 embeddings = AzureOpenAIEmbeddings(model="text-embedding-3-small")
+```
+
+> [!WARNING]
+> model には、Azure OpenAI Service で設定したデプロイ名を設定します。
+
+## LangChain の init_embeddings
+
+LangChain の init_embeddings を使用する箇所は、以下のように変更します。
+
+変更前
+
+```python
+from langchain.embeddings import init_embeddings
+
+embeddings = init_embeddings(model="text-embedding-3-small", provider="openai")
+```
+
+変更後
+
+```python
+from langchain.embeddings import init_embeddings
+
+embeddings = init_embeddings(model="text-embedding-3-small", provider="azure_openai")
 ```
 
 > [!WARNING]


### PR DESCRIPTION
- LangChainのinit_chat_model関数をAzure OpenAIで使用する方法を追記
- LangChainのinit_embeddings関数をAzure OpenAIで使用する方法を追記
- 各セクションに必要なパラメータとデプロイ名に関する警告を含める

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能

- バグ修正

- ドキュメント
  - LangChain の使用方法を Azure OpenAI 向けに全面更新。
  - ChatOpenAI を AzureChatOpenAI に変更し、azure_deployment と api_version の指定例を追加。
  - LangChain の init_chat_model セクションを追加（provider="azure_openai", api_version="2024-08-01-preview"）。
  - OpenAIEmbeddings を AzureOpenAIEmbeddings に刷新。
  - LangChain の init_embeddings セクションを追加（provider="azure_openai"）。
  - モデルのデプロイ名が Azure OpenAI の設定と一致する必要がある旨の注意を追記。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->