### PR TITLE
code-server の起動フォルダを本リポジトリに変更

### DIFF
--- a/setup/ec2_code_server.yaml
+++ b/setup/ec2_code_server.yaml
@@ -483,6 +483,6 @@ Outputs:
       Name: !Sub ${AWS::StackName}-Password
   URL:
     Description: code-server URL
-    Value: !Sub https://${Distribution.DomainName}/?folder=/home/ubuntu/environment/training-llm-application-development-starter
+    Value: !Sub https://${Distribution.DomainName}/?folder=/home/ubuntu/environment/training-llm-application-development
     Export:
       Name: !Sub ${AWS::StackName}-URL


### PR DESCRIPTION
ec2_code_server.yaml の出力する code-server URL の folder パスを、starter 専用 リポジトリ名から本リポジトリ名に変更した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * インフラストラクチャの設定を更新し、環境のデフォルトパスを調整しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GenerativeAgents/training-llm-application-development/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->