### PR TITLE
day3/day3-starter の web に basePath 対応を追加

### DIFF
--- a/day3-starter/CLAUDE.md
+++ b/day3-starter/CLAUDE.md
@@ -93,3 +93,5 @@ TypeScript path alias `@/*` maps to `web/src/*` (configured in tsconfig.json).
 
 - このリポジトリは研修・ハンズオン教材であり、本番運用ではない。DB (`web/data/inquiries.db`) は消して再シードする選択を躊躇なく取ってよい。後方互換シム、ALTER TABLE による既存DBマイグレーション、廃止フィールドのエイリアスなどは書かない。スキーマ変更は `web/src/lib/db.ts` の `initSchema` を直接書き換えて再シードで対応する。
 - 永続化したい知見・ルールはこの `CLAUDE.md` に追記する方針(memory システムは使わない)。
+- code-server などで `/absproxy/3000` 配下にホストする場合は `web/.env` を作成し、`NEXT_PUBLIC_BASE_PATH=/absproxy/3000` と必要に応じて `ALLOWED_DEV_ORIGINS=*.cloudfront.net` を設定する(`web/.env.example` 参照)。ローカル開発時は `.env` を作らない。`.env*` は gitignored で、サンプルの `.env.example` のみコミット対象。
+- client-side fetch でアプリ内 API を叩く際は `web/src/lib/api-path.ts` の `apiPath()` を必ず経由する(basePath プレフィックスを自動付与)。`<Link>` や `useRouter` は Next.js が自動処理するので不要。サーバー側から FastAPI を叩く `LLM_API_URL` 経由の fetch には不要。

--- a/day3-starter/web/.env.example
+++ b/day3-starter/web/.env.example
@@ -1,0 +1,8 @@
+# code-server などで /absproxy/3000 配下にホストする場合に設定
+# NEXT_PUBLIC_BASE_PATH=/absproxy/3000
+
+# code-server の cross-origin リクエスト許可(dev サーバーのみ有効、本番には影響なし)
+# ALLOWED_DEV_ORIGINS=*.cloudfront.net
+
+# FastAPI (llm-app) の URL。Next.js サーバーからのみ参照される
+# LLM_API_URL=http://localhost:8000

--- a/day3-starter/web/.gitignore
+++ b/day3-starter/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/day3-starter/web/next.config.ts
+++ b/day3-starter/web/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;
+const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS
+  ?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  ...(basePath ? { basePath } : {}),
+  ...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
 };
 
 export default nextConfig;

--- a/day3-starter/web/src/app/admin/_hooks/use-draft-editor.ts
+++ b/day3-starter/web/src/app/admin/_hooks/use-draft-editor.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { Inquiry, InquiryTopic } from "@/lib/db";
+import { apiPath } from "@/lib/api-path";
 
 interface UseDraftEditorParams {
   selectedInquiry: Inquiry | null;
@@ -58,7 +59,7 @@ export function useDraftEditor({
     body: string,
   ): Promise<void> {
     const response = await fetch(
-      `/api/admin/inquiries/${inquiryId}/${endpoint}`,
+      apiPath(`/api/admin/inquiries/${inquiryId}/${endpoint}`),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -123,7 +124,7 @@ export function useDraftEditor({
     });
     try {
       const response = await fetch(
-        `/api/admin/inquiries/${selectedInquiry.id}/topic`,
+        apiPath(`/api/admin/inquiries/${selectedInquiry.id}/topic`),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/day3-starter/web/src/app/admin/_hooks/use-inquiries.ts
+++ b/day3-starter/web/src/app/admin/_hooks/use-inquiries.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { Inquiry, InquiryListItem } from "@/lib/db";
+import { apiPath } from "@/lib/api-path";
 
 export function useInquiries() {
   const [inquiries, setInquiries] = useState<InquiryListItem[]>([]);
@@ -22,7 +23,7 @@ export function useInquiries() {
       }
       params.set("limit", "50");
 
-      const response = await fetch(`/api/admin/inquiries?${params}`);
+      const response = await fetch(apiPath(`/api/admin/inquiries?${params}`));
       if (!response.ok) throw new Error("Failed to fetch inquiries");
 
       const data = await response.json();
@@ -36,7 +37,7 @@ export function useInquiries() {
 
   const fetchInquiryDetail = useCallback(async (id: string) => {
     try {
-      const response = await fetch(`/api/admin/inquiries/${id}`);
+      const response = await fetch(apiPath(`/api/admin/inquiries/${id}`));
       if (!response.ok) throw new Error("Failed to fetch inquiry details");
 
       const data: Inquiry = await response.json();
@@ -53,7 +54,7 @@ export function useInquiries() {
       setIsRetrying(true);
       try {
         const response = await fetch(
-          `/api/admin/inquiries/${id}/retry`,
+          apiPath(`/api/admin/inquiries/${id}/retry`),
           { method: "POST" }
         );
         if (!response.ok) throw new Error("Failed to retry generation");

--- a/day3-starter/web/src/app/page.tsx
+++ b/day3-starter/web/src/app/page.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { HealthCheckModal } from "@/components/health-check-modal";
+import { apiPath } from "@/lib/api-path";
 
 export default function Home() {
   const [formData, setFormData] = useState({
@@ -39,7 +40,7 @@ export default function Home() {
     setError(null);
 
     try {
-      const response = await fetch("/api/inquiries", {
+      const response = await fetch(apiPath("/api/inquiries"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/day3-starter/web/src/components/health-check-modal.tsx
+++ b/day3-starter/web/src/components/health-check-modal.tsx
@@ -10,12 +10,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { apiPath } from "@/lib/api-path";
 
 export function HealthCheckModal() {
   const [healthError, setHealthError] = useState(false);
 
   useEffect(() => {
-    fetch("/api/health")
+    fetch(apiPath("/api/health"))
       .then((res) => {
         if (!res.ok) setHealthError(true);
       })

--- a/day3-starter/web/src/lib/api-path.ts
+++ b/day3-starter/web/src/lib/api-path.ts
@@ -1,0 +1,8 @@
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+// Next.js の API route などアプリ内パスに basePath を付与する。
+// <Link> や useRouter は Next.js が自動で basePath を付けるため、
+// 用途は client-side の fetch / window.location など「素のパス」を扱う場面に限る。
+export function apiPath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/day3/CLAUDE.md
+++ b/day3/CLAUDE.md
@@ -93,3 +93,5 @@ TypeScript path alias `@/*` maps to `web/src/*` (configured in tsconfig.json).
 
 - このリポジトリは研修・ハンズオン教材であり、本番運用ではない。DB (`web/data/inquiries.db`) は消して再シードする選択を躊躇なく取ってよい。後方互換シム、ALTER TABLE による既存DBマイグレーション、廃止フィールドのエイリアスなどは書かない。スキーマ変更は `web/src/lib/db.ts` の `initSchema` を直接書き換えて再シードで対応する。
 - 永続化したい知見・ルールはこの `CLAUDE.md` に追記する方針(memory システムは使わない)。
+- code-server などで `/absproxy/3000` 配下にホストする場合は `web/.env` を作成し、`NEXT_PUBLIC_BASE_PATH=/absproxy/3000` と必要に応じて `ALLOWED_DEV_ORIGINS=*.cloudfront.net` を設定する(`web/.env.example` 参照)。ローカル開発時は `.env` を作らない。`.env*` は gitignored で、サンプルの `.env.example` のみコミット対象。
+- client-side fetch でアプリ内 API を叩く際は `web/src/lib/api-path.ts` の `apiPath()` を必ず経由する(basePath プレフィックスを自動付与)。`<Link>` や `useRouter` は Next.js が自動処理するので不要。サーバー側から FastAPI を叩く `LLM_API_URL` 経由の fetch には不要。

--- a/day3/web/.env.example
+++ b/day3/web/.env.example
@@ -1,0 +1,8 @@
+# code-server などで /absproxy/3000 配下にホストする場合に設定
+# NEXT_PUBLIC_BASE_PATH=/absproxy/3000
+
+# code-server の cross-origin リクエスト許可(dev サーバーのみ有効、本番には影響なし)
+# ALLOWED_DEV_ORIGINS=*.cloudfront.net
+
+# FastAPI (llm-app) の URL。Next.js サーバーからのみ参照される
+# LLM_API_URL=http://localhost:8000

--- a/day3/web/.gitignore
+++ b/day3/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/day3/web/next.config.ts
+++ b/day3/web/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;
+const allowedDevOrigins = process.env.ALLOWED_DEV_ORIGINS
+  ?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  ...(basePath ? { basePath } : {}),
+  ...(allowedDevOrigins?.length ? { allowedDevOrigins } : {}),
 };
 
 export default nextConfig;

--- a/day3/web/src/app/admin/_hooks/use-draft-editor.ts
+++ b/day3/web/src/app/admin/_hooks/use-draft-editor.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { Inquiry, InquiryTopic } from "@/lib/db";
+import { apiPath } from "@/lib/api-path";
 
 interface UseDraftEditorParams {
   selectedInquiry: Inquiry | null;
@@ -58,7 +59,7 @@ export function useDraftEditor({
     body: string,
   ): Promise<void> {
     const response = await fetch(
-      `/api/admin/inquiries/${inquiryId}/${endpoint}`,
+      apiPath(`/api/admin/inquiries/${inquiryId}/${endpoint}`),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -123,7 +124,7 @@ export function useDraftEditor({
     });
     try {
       const response = await fetch(
-        `/api/admin/inquiries/${selectedInquiry.id}/topic`,
+        apiPath(`/api/admin/inquiries/${selectedInquiry.id}/topic`),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/day3/web/src/app/admin/_hooks/use-inquiries.ts
+++ b/day3/web/src/app/admin/_hooks/use-inquiries.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { Inquiry, InquiryListItem } from "@/lib/db";
+import { apiPath } from "@/lib/api-path";
 
 export function useInquiries() {
   const [inquiries, setInquiries] = useState<InquiryListItem[]>([]);
@@ -22,7 +23,7 @@ export function useInquiries() {
       }
       params.set("limit", "50");
 
-      const response = await fetch(`/api/admin/inquiries?${params}`);
+      const response = await fetch(apiPath(`/api/admin/inquiries?${params}`));
       if (!response.ok) throw new Error("Failed to fetch inquiries");
 
       const data = await response.json();
@@ -36,7 +37,7 @@ export function useInquiries() {
 
   const fetchInquiryDetail = useCallback(async (id: string) => {
     try {
-      const response = await fetch(`/api/admin/inquiries/${id}`);
+      const response = await fetch(apiPath(`/api/admin/inquiries/${id}`));
       if (!response.ok) throw new Error("Failed to fetch inquiry details");
 
       const data: Inquiry = await response.json();
@@ -53,7 +54,7 @@ export function useInquiries() {
       setIsRetrying(true);
       try {
         const response = await fetch(
-          `/api/admin/inquiries/${id}/retry`,
+          apiPath(`/api/admin/inquiries/${id}/retry`),
           { method: "POST" }
         );
         if (!response.ok) throw new Error("Failed to retry generation");

--- a/day3/web/src/app/page.tsx
+++ b/day3/web/src/app/page.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { HealthCheckModal } from "@/components/health-check-modal";
+import { apiPath } from "@/lib/api-path";
 
 export default function Home() {
   const [formData, setFormData] = useState({
@@ -39,7 +40,7 @@ export default function Home() {
     setError(null);
 
     try {
-      const response = await fetch("/api/inquiries", {
+      const response = await fetch(apiPath("/api/inquiries"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/day3/web/src/components/health-check-modal.tsx
+++ b/day3/web/src/components/health-check-modal.tsx
@@ -10,12 +10,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { apiPath } from "@/lib/api-path";
 
 export function HealthCheckModal() {
   const [healthError, setHealthError] = useState(false);
 
   useEffect(() => {
-    fetch("/api/health")
+    fetch(apiPath("/api/health"))
       .then((res) => {
         if (!res.ok) setHealthError(true);
       })

--- a/day3/web/src/lib/api-path.ts
+++ b/day3/web/src/lib/api-path.ts
@@ -1,0 +1,8 @@
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+// Next.js の API route などアプリ内パスに basePath を付与する。
+// <Link> や useRouter は Next.js が自動で basePath を付けるため、
+// 用途は client-side の fetch / window.location など「素のパス」を扱う場面に限る。
+export function apiPath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/scripts/generate-day3-starter/include.txt
+++ b/scripts/generate-day3-starter/include.txt
@@ -30,6 +30,7 @@ llm-app/app
 llm-app/evals/__init__.py
 
 # --- web/ ---
+web/.env.example
 web/.gitignore
 web/README.md
 web/components.json


### PR DESCRIPTION
code-server などの /absproxy/3000 配下でホストできるよう、NEXT_PUBLIC_BASE_PATH と ALLOWED_DEV_ORIGINS を next.config.ts から読み、client-side fetch は apiPath() ヘルパー経由に統一。あわせて include.txt に web/.env.example を追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロキシ経由でのホストに対応し、ベースパス設定により `/absproxy/3000` 配下でのサービス提供が可能になりました。

* **その他**
  * 環境変数設定の例示ファイルを追加しました。
  * 開発環境のクロスオリジン許可設定に対応しました。
  * 設定ドキュメントを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GenerativeAgents/training-llm-application-development/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->