### PR TITLE
day3-starter の GenerateResponse の run_id を weave_call_id にリネーム

### DIFF
--- a/day3-starter/llm-app/app/main.py
+++ b/day3-starter/llm-app/app/main.py
@@ -41,7 +41,7 @@ class GenerateResponse(BaseModel):
     topic: TopicType
     classification_confidence: float
     generated_draft: GeneratedDraft | None
-    run_id: str | None
+    weave_call_id: str | None
 
 
 @app.post("/api/generate")

--- a/scripts/generate-day3-starter/overrides/llm-app/app/main.py
+++ b/scripts/generate-day3-starter/overrides/llm-app/app/main.py
@@ -41,7 +41,7 @@ class GenerateResponse(BaseModel):
     topic: TopicType
     classification_confidence: float
     generated_draft: GeneratedDraft | None
-    run_id: str | None
+    weave_call_id: str | None
 
 
 @app.post("/api/generate")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## API更新

* `GenerateResponse` のレスポンス構造を更新。`run_id` フィールドが `weave_call_id` に変更されました。API利用者は新しいフィールド名に対応してください。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GenerativeAgents/training-llm-application-development/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->