### PR TITLE
day3/day3-starter の web の generateDraft のタイムアウトを 60 秒から 300 秒に延長

### DIFF
--- a/day3-starter/web/src/lib/llm.ts
+++ b/day3-starter/web/src/lib/llm.ts
@@ -34,7 +34,7 @@ export async function generateDraft(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(300_000),
   });
 
   if (!response.ok) {

--- a/day3/web/src/lib/llm.ts
+++ b/day3/web/src/lib/llm.ts
@@ -34,7 +34,7 @@ export async function generateDraft(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(300_000),
   });
 
   if (!response.ok) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * LLM API呼び出しの最大実行時間を延長しました。これにより、処理時間が長い操作でもタイムアウトなく完了できるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GenerativeAgents/training-llm-application-development/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->