### PR TITLE
hybrid RAG の BM25 ドキュメントの source パス先頭に ../ を付与

### DIFF
--- a/day2/app/advanced_rag/chains/hybrid.py
+++ b/day2/app/advanced_rag/chains/hybrid.py
@@ -77,6 +77,9 @@ class HybridRAGChain(BaseRAGChain):
             loader_cls=PyPDFLoader,
         )
         documents = loader.load()
+        # メタデータのファイルパス先頭に "../" を付与して Chroma 側の source 表記に揃える
+        for document in documents:
+            document.metadata["source"] = "../" + document.metadata["source"]
         self.bm25_retriever = BM25Retriever.from_documents(documents, k=20).with_config(
             {"run_name": "bm25_retriever"}
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ドキュメントメタデータのソースパス表記を統一しました。これにより、検索・融合処理時のドキュメント参照の一貫性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->